### PR TITLE
Update VulnerabilityDB.php - don't schedule if no API key.

### DIFF
--- a/component/Security/VulnerabilityDB.php
+++ b/component/Security/VulnerabilityDB.php
@@ -96,6 +96,13 @@ class VulnerabilityDB
 
     public function schedule()
     {
+        // do we have an API key?
+        $settings = get_option('moj_component_settings', []);
+        if (!isset($settings['vulndb_token']) || empty($settings['vulndb_token'])) {
+            // We don't have an API key so don't schedule checks.
+            return false;
+        }
+
         if (!wp_next_scheduled('moj_check_vulnerabilities')) {
             wp_schedule_event(time(), 'daily', 'moj_check_vulnerabilities');
 
@@ -103,11 +110,10 @@ class VulnerabilityDB
         }
 
         // force check
-        $options = get_option('moj_component_settings', '');
-        if (isset($options['force_collect']) && $options['force_collect'] == 'yes') {
+        if (isset($settings['force_collect']) && $settings['force_collect'] == 'yes') {
             // reset
-            $options['force_collect'] = '';
-            update_option('moj_component_settings', $options);
+            $settings['force_collect'] = '';
+            update_option('moj_component_settings', $settings);
 
             wp_clear_scheduled_hook('moj_check_vulnerabilities');
             wp_schedule_single_event(time(), 'moj_check_vulnerabilities');


### PR DESCRIPTION
Due to the way WordPress cron scheduling works, all scheduled events are stored in a single row in options table of the  database.

Every time a scheduled event is run, this row is read and updated.

This PR is an effort to reduce the size of the data in that column, by removing unnecessary entries.