### PR TITLE
Update Users.php - don't schedule if feature is disabled.

### DIFF
--- a/component/Users/Users.php
+++ b/component/Users/Users.php
@@ -187,6 +187,12 @@ class Users
      */
     public function addSchedule()
     {
+        // Is this feature disabled in the settings?
+        $options = get_option('moj_component_settings');
+        if (isset($options['user_active_disable']) && $options['user_active_disable'] === 'yes') {
+            return false;
+        }
+
         $recurrence = get_option('moj_component_settings', array()); // default to monthly
         $recurrence = $recurrence['user_inactive_schedule'] ?? 'monthly';
         $now_recurrence = wp_get_schedule('moj_check_user_activity');


### PR DESCRIPTION
Due to the way WordPress cron scheduling works, all scheduled events are stored in a single row in options table of the  database.

Every time a scheduled event is run, this row is read and updated.

This PR is an effort to reduce the size of the data in that column, by removing unnecessary entries.